### PR TITLE
allow edges to have different dimension in SFLU graphs

### DIFF
--- a/src/wavestate/control/SFLU/SFLUcompute.py
+++ b/src/wavestate/control/SFLU/SFLUcompute.py
@@ -67,7 +67,8 @@ class SFLUCompute:
         return
 
     def CLG_inv(self, E):
-        return np.linalg.inv(self.eye - E)
+        # return np.linalg.inv(self.eye - E)
+        return np.linalg.inv(np.eye(E.shape[-1]) - E)
 
     def typemap_to_default(self, v):
         """
@@ -159,7 +160,12 @@ class SFLUCompute:
                 # (arg,) = op.args
                 # size = self.nodesizes.get(arg, self.defaultsize)
                 # I = np.eye(size)
-                Espace[op.targ] = self.eye
+                for ek, ev in Espace.items():
+                    if ek.r == op.args[0]:
+                        rdim = ev.shape[-2]  # row dimension of incoming edge
+                        break
+                Espace[op.targ] = np.eye(rdim)
+                # Espace[op.targ] = self.eye
 
             elif op.op == "E_mul2":
                 arg1, arg2 = op.args


### PR DESCRIPTION
This allows edges to have different dimensions in SFLU graphs. One place this is necessary is to compute the mechanical part of optomechanical calculations which is required for, among other things, calculating PI gains.

It modifies two methods in `SFLUCompute`

1. A simple change to find the dimensions of the identity matrix in `CLG_inv`
2. A change to find the dimensions of incoming rows when the operation is `E_CLGd` in the `compute` method. There is certainly a better way to do this and this merge request probably shouldn't be merged as is.