### PR TITLE
fix minor MIMO function naming bugs

### DIFF
--- a/src/wavestate/control/MIMO/response.py
+++ b/src/wavestate/control/MIMO/response.py
@@ -109,7 +109,7 @@ class MIMOFResponse(mimo.MIMO):
         """
         r = self.outputs[row]
         c = self.inputs[col]
-        return SISO.SISOResponse(
+        return SISO.response.SISOFResponse(
             tf=self.tf_sm[..., r, c],
             **self.__init_kw()
         )

--- a/src/wavestate/control/MIMO/ss.py
+++ b/src/wavestate/control/MIMO/ss.py
@@ -173,7 +173,7 @@ class MIMOStateSpace(RawStateSpaceUser, mimo.MIMO):
         return
 
     def fresponse(self, *, f=None, w=None, s=None):
-        tf = xfer_algorithms.ss.fresponse_raw(f=f, s=s, w=w)
+        tf = self.ss.fresponse_raw(f=f, s=s, w=w)
         return response.MIMOFResponse(
             tf=tf,
             w=w,


### PR DESCRIPTION
Fix minor function naming bugs probably introduced when refactoring.