### PR TITLE
Mimo tweaks

### DIFF
--- a/src/wavestate/control/MIMO/ss.py
+++ b/src/wavestate/control/MIMO/ss.py
@@ -11,6 +11,7 @@
 from collections.abc import Mapping
 import numbers
 import numpy as np
+from copy import deepcopy
 
 from wavestate.bunch import Bunch
 
@@ -282,8 +283,8 @@ class MIMOStateSpace(RawStateSpaceUser, mimo.MIMO):
 
         return self.__class__(
             ss=ss,
-            inputs=self.inputs,
-            outputs=self.outputs,
+            inputs=deepcopy(self.inputs),
+            outputs=deepcopy(self.outputs),
         )
 
 

--- a/src/wavestate/control/MIMO/util.py
+++ b/src/wavestate/control/MIMO/util.py
@@ -10,6 +10,7 @@
 import numbers
 import numpy as np
 import warnings
+from copy import deepcopy
 
 
 def io_idx_normalize(idx, Nmax):
@@ -39,6 +40,8 @@ def io_normalize(io_arg, Nmax):
         if isinstance(io_arg, (list, tuple)):
             # convert to a dictionary
             io_arg = {k: i for i, k in enumerate(io_arg)}
+        elif isinstance(io_arg, dict):
+            io_arg = deepcopy(io_arg)
         else:
             io_arg2 = {}
             while io_arg:


### PR DESCRIPTION
* Copy inputs and outputs in `MIMOStateSpace.feedback_connect`. The inputs and outputs of the original object can be deleted without copying.
* Tweak `util.io_normalize` so that it works with dictionaries again as the docstring describes.