### PR TITLE
fix bug in how Mapping is imported

### DIFF
--- a/src/wavestate/control/MIMO/util.py
+++ b/src/wavestate/control/MIMO/util.py
@@ -10,8 +10,12 @@
 import numbers
 import numpy as np
 import warnings
-from collections import Mapping
 from copy import deepcopy
+
+try:
+    from collections import Mapping
+except ImportError:
+    from collections.abc import Mapping
 
 
 def io_idx_normalize(idx, Nmax):


### PR DESCRIPTION
Before python 3.3 it was in collections, after it's in collections.abc:
https://docs.python.org/3/library/collections.abc.html