### PR TITLE
remove unnecessary declarative imports

### DIFF
--- a/src/wield/control/ACE/ace_electrical.py
+++ b/src/wield/control/ACE/ace_electrical.py
@@ -11,7 +11,6 @@ State Space System
 
 import numpy as np
 import copy
-from wield import declarative
 from collections import defaultdict, Mapping
 import functools
 from numbers import Number

--- a/src/wield/control/ACE/ace_optical.py
+++ b/src/wield/control/ACE/ace_optical.py
@@ -11,7 +11,6 @@ State Space System
 
 import numpy as np
 import copy
-from wield import declarative
 from collections import defaultdict, Mapping
 import functools
 from numbers import Number

--- a/src/wield/control/TFmath/roots_matching.py
+++ b/src/wield/control/TFmath/roots_matching.py
@@ -9,7 +9,6 @@
 """
 
 import numpy as np
-from wield import declarative
 
 
 def nearest_idx(

--- a/src/wield/control/algorithms/statespace/dense/slycot_algorithms.py
+++ b/src/wield/control/algorithms/statespace/dense/slycot_algorithms.py
@@ -8,7 +8,6 @@
 """
 """
 
-from wield import declarative
 import numpy as np
 
 import slycot

--- a/src/wield/control/statespace/fixme/test/IFO_model.py
+++ b/src/wield/control/statespace/fixme/test/IFO_model.py
@@ -10,7 +10,6 @@
 
 import numpy as np
 import copy
-from wield import declarative
 
 from wield.utilities.np import logspaced
 from wield.utilities.mpl import mplfigB

--- a/src/wield/control/statespace/fixme/test/IFO_model_noM.py
+++ b/src/wield/control/statespace/fixme/test/IFO_model_noM.py
@@ -10,7 +10,6 @@
 
 import numpy as np
 import copy
-from wield import declarative
 
 from wield.utilities.np import logspaced
 from wield.utilities.mpl import mplfigB

--- a/src/wield/control/statespace/fixme/test/test_IFO_model.py
+++ b/src/wield/control/statespace/fixme/test/test_IFO_model.py
@@ -11,7 +11,6 @@
 import numpy as np
 import pytest
 import copy
-from wield import declarative
 import wield.control
 
 from wield.utilities.np import logspaced

--- a/src/wield/control/statespace/fixme/test/test_escher.py
+++ b/src/wield/control/statespace/fixme/test/test_escher.py
@@ -10,7 +10,6 @@
 
 import numpy as np
 import copy
-from wield import declarative
 import wield.control
 import pytest
 

--- a/src/wield/control/statespace/fixme/test/test_minreal.py
+++ b/src/wield/control/statespace/fixme/test/test_minreal.py
@@ -11,7 +11,6 @@
 import numpy as np
 import pytest
 import copy
-from wield import declarative
 import wield.control
 
 from wield.utilities.np import logspaced

--- a/src/wield/control/statespace/fixme/test/test_minreal.py_
+++ b/src/wield/control/statespace/fixme/test/test_minreal.py_
@@ -11,7 +11,6 @@
 import numpy as np
 import pytest
 import copy
-from wield import declarative
 import wield.control
 
 from wield.utilities.np import logspaced


### PR DESCRIPTION
removes all the imports of `wield.declarative` since they aren't actually used and this reduces dependencies.