### PR TITLE
np.complex Deprecation 

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,7 +17,7 @@ Timeline of contributions:
 
 2021-: Lee McCuller is a principle contributor and maintainer of python wield.
 Wavestate is originally constructed from a set of software projects related to
-the LIGO graviational-wave observatories and optical squeezing research at MIT.
+the LIGO gravitational-wave observatories and optical squeezing research at MIT.
 
 2023: Ian MacMillan is a graduate student at Caltech in Prof. Lee McCuller's 
 group. He is the mainly involved in the development of the optimal controls

--- a/NOTICE
+++ b/NOTICE
@@ -18,3 +18,7 @@ Timeline of contributions:
 2021-: Lee McCuller is a principle contributor and maintainer of python wield.
 Wavestate is originally constructed from a set of software projects related to
 the LIGO graviational-wave observatories and optical squeezing research at MIT.
+
+2023: Ian MacMillan is a graduate student at Caltech in Prof. Lee McCuller's 
+group. He is the mainly involved in the development of the optimal controls
+package buzz. 

--- a/src/wield/control/SISO/zpk_d2c_c2d.py
+++ b/src/wield/control/SISO/zpk_d2c_c2d.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: © 2022 Lee McCuller <mcculler@caltech.edu>
 # NOTICE: authors should document their contributions in concisely in NOTICE
 # with details inline in source files, comments, and docstrings.
+#
+# 12-6-23: Ian MacMillan (Caltech): updated np.complex after deprecation
 """
 Perform discrete to continuous conversion
 """

--- a/src/wield/control/SISO/zpk_d2c_c2d.py
+++ b/src/wield/control/SISO/zpk_d2c_c2d.py
@@ -37,7 +37,7 @@ def d2c_zpk(zpk_z, fs, method="tustin"):
     fmax = fs * 3 / 8.0
 
     nzz, npz = len(zz), len(pz)
-    zs, ps = np.zeros(nzz, dtype=np.complex), np.zeros(npz, dtype=np.complex)
+    zs, ps = np.zeros(nzz, dtype=complex), np.zeros(npz, dtype=complex)
     ks = kz
 
     method = method.lower()
@@ -62,11 +62,11 @@ def d2c_zpk(zpk_z, fs, method="tustin"):
             ks /= 1.0 + pz[i]
 
         if npz > nzz:
-            zs_pad = fs2x * np.ones(npz - nzz, dtype=np.complex)
+            zs_pad = fs2x * np.ones(npz - nzz, dtype=complex)
             zs = np.hstack([zs, zs_pad])
             ks *= (-1)**(npz - nzz)
         elif nzz > npz:
-            ps_pad = fs2x * np.ones(nzz - npz, dtype=np.complex)
+            ps_pad = fs2x * np.ones(nzz - npz, dtype=complex)
             ps = np.hstack([ps, ps_pad])
             ks *= (-1)**(nzz - npz)
 
@@ -98,8 +98,8 @@ def c2d_zpk(zpk_s, *, method, dt=None, fs=None, pad=None):
 
     nzs = len(zs)
     nps = len(ps)
-    zz = np.zeros(nzs, dtype=np.complex)
-    pz = np.zeros(nps, dtype=np.complex)
+    zz = np.zeros(nzs, dtype=complex)
+    pz = np.zeros(nps, dtype=complex)
 
     kz = ks
 
@@ -140,10 +140,10 @@ def c2d_zpk(zpk_s, *, method, dt=None, fs=None, pad=None):
     if pad:
         kadj *= (2.0 - 1/fs)**float(nzs - nps)
         if nps > nzs:
-            zz_pad = -np.ones(nps - nzs, dtype=np.complex) * (1 - 1 / fs)
+            zz_pad = -np.ones(nps - nzs, dtype=complex) * (1 - 1 / fs)
             zz = np.hstack([zz, zz_pad])
         elif nzs > nps:
-            pz_pad = -np.ones(nzs - nps, dtype=np.complex) * (1 - 1 / fs)
+            pz_pad = -np.ones(nzs - nps, dtype=complex) * (1 - 1 / fs)
             pz = np.hstack([pz, pz_pad])
 
     kz *= kadj


### PR DESCRIPTION
When using the most recent version of numpy I would get the error:
```
`np.complex` was a deprecated alias for the builtin `complex`. To avoid this error in existing code, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
```
from the file /wield-control/src/wield/control/SISO/zpk_d2c_c2d.py. I changed all of the mentions of `np.complex` to "the built-in `complex`. This is the link to the [list of deprecations in numpy 1.20.0](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)

NOTE: I did not change any instances of `np.complex128` as this is still a valid numpy scalar type