### PR TITLE
Algo select zpk to not call itself

### DIFF
--- a/src/wield/control/SISO/ss.py
+++ b/src/wield/control/SISO/ss.py
@@ -121,7 +121,7 @@ class SISOStateSpace(BareStateSpaceUser, siso.SISOCommonBase):
         z, p = self._zp
         # the gain is not specified here,
         # as it is established from the fiducial data
-        self._ZPK = zpk.zpk(
+        self._ZPK = zpk(
             z, p,
             hermitian=self.ss.hermitian,
             time_symm=self.ss.time_symm,


### PR DESCRIPTION
In line 124 of [wield.control.SISO.ss](https://github.com/wieldphysics/wield-control/blob/82a8c0c7f3d45aaa4c1506011813ed44bc2bcac2/src/wield/control/SISO/ss.py#L124), the function [zpk](https://github.com/wieldphysics/wield-control/blob/82a8c0c7f3d45aaa4c1506011813ed44bc2bcac2/src/wield/control/SISO/zpk.py#L522) is being called then it is being asked for an attribute. I think it should be changed from
```python
self._ZPK = zpk.zpk(
```
to
```python
self._ZPK = zpk(
```
zpk is a function without an attribute called `zpk` so it throws an error